### PR TITLE
Do not compress backups if config has 'compress: True'.

### DIFF
--- a/bakthat/__init__.py
+++ b/bakthat/__init__.py
@@ -253,7 +253,7 @@ def backup(filename=os.getcwd(), destination=None, prompt="yes", tags=[], profil
                 return
 
     # Check if compression is disabled on the configuration.
-    if not config.get('compress', True):
+    if not config.get(profile, {}).get('compress', True):
         log.info("Compression disabled")
         outname = filename
         with open(outname) as outfile:

--- a/bakthat/__init__.py
+++ b/bakthat/__init__.py
@@ -252,8 +252,15 @@ def backup(filename=os.getcwd(), destination=None, prompt="yes", tags=[], profil
                 log.error("Password confirmation doesn't match")
                 return
 
+    # Check if compression is disabled on the configuration.
+    if not config.get('compress', True):
+        log.info("Compression disabled")
+        outname = filename
+        with open(outname) as outfile:
+            backup_data["size"] = os.fstat(outfile.fileno()).st_size
+        bakthat_compression = False
     # Check if the file is not already compressed
-    if mimetypes.guess_type(arcname) == ('application/x-tar', 'gzip'):
+    elif mimetypes.guess_type(arcname) == ('application/x-tar', 'gzip'):
         log.info("File already compressed")
         outname = filename
 


### PR DESCRIPTION
I need to run bakthat without compression. This code bypasses compression if 'compress: true' is found on the config file.

I didn't write any tests for it, please check that what I'm doing is reasonable. It's not clear what 'outname' and 'backup_data["size"]' are used for, but I added it anyways (you can call it cargo-cult-driven-development).
