### PR TITLE
Allow to set password in configuration

### DIFF
--- a/bakthat/__init__.py
+++ b/bakthat/__init__.py
@@ -286,7 +286,18 @@ def backup(filename=os.getcwd(), destination=None, profile="default", config=CON
     # Useful only when using bakmanager.io hook
     backup_key = key
 
-    password = kwargs.get("password", os.environ.get("BAKTHAT_PASSWORD"))
+    # Check if a password is set in the configuration.
+    if conf:
+        password = conf.get("password", None)
+    else:
+        password = config.get(profile).get("password", None)
+
+    # Password may still be overridden by environment variable BAKTHAT_PASSWORD
+    # or when given as argument
+    if kwargs.get("password", os.environ.get("BAKTHAT_PASSWORD")):
+        password = kwargs.get("password", os.environ.get("BAKTHAT_PASSWORD"))
+
+    # If we still have no password and prompt is not disabled, prompt for it
     if password is None and prompt.lower() != "no":
         password = getpass("Password (blank to disable encryption): ")
         if password:


### PR DESCRIPTION
A small patch to allow users to define a general password in the yaml config.
Should not change default behaviour (config is overridden by ENV, which is overridden by kwargs - like before) and should work with "default" and profile specific passwords
