### PR TITLE
add 'importlib' to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pycrypto
 requests
 sh
 events
+importlib


### PR DESCRIPTION
fixes for Python 2.6.6

```
$ bakthat configure
Traceback (most recent call last):
  File "/usr/local/bin/bakthat", line 9, in <module>
    load_entry_point('bakthat==0.6.0', 'console_scripts', 'bakthat')()
  File "/usr/lib/python2.6/dist-packages/pkg_resources.py", line 305, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/lib/python2.6/dist-packages/pkg_resources.py", line 2244, in load_entry_point
    return ep.load()
  File "/usr/lib/python2.6/dist-packages/pkg_resources.py", line 1954, in load
    entry = __import__(self.module_name, globals(),globals(), ['__name__'])
  File "/usr/local/lib/python2.6/dist-packages/bakthat-0.6.0-py2.6.egg/bakthat/__init__.py", line 30, in <module>
    from bakthat.plugin import setup_plugins, plugin_setup
  File "/usr/local/lib/python2.6/dist-packages/bakthat-0.6.0-py2.6.egg/bakthat/plugin.py", line 2, in <module>
    import importlib
ImportError: No module named importlib
```
