### PR TITLE
Allowing you to use config dict

### DIFF
--- a/bakthat/__init__.py
+++ b/bakthat/__init__.py
@@ -50,7 +50,7 @@ STORAGE_BACKEND = dict(s3=S3Backend, glacier=GlacierBackend, swift=SwiftBackend)
 def _get_store_backend(conf, destination=None, profile="default"):
     if not isinstance(conf, dict):
         conf = load_config(conf)
-    conf = conf.get(profile)
+    conf = conf.get(profile, conf)
     setup_plugins(conf)
     if not destination:
         destination = conf.get("default_destination", DEFAULT_DESTINATION)

--- a/bakthat/__init__.py
+++ b/bakthat/__init__.py
@@ -352,6 +352,7 @@ def backup(filename=os.getcwd(), destination=None, profile="default", config=CON
 
     backup_data["metadata"] = dict(is_enc=bakthat_encryption,
                                    client=socket.gethostname())
+    stored_filename = os.path.join(os.path.dirname(kwargs.get("custom_filename", "")), stored_filename)
     backup_data["stored_filename"] = stored_filename
 
     access_key = storage_backend.conf.get("access_key")
@@ -520,7 +521,6 @@ def restore(filename, destination=None, profile="default", config=CONFIG_FILE, *
             password = getpass()
 
     log.info("Downloading...")
-
     download_kwargs = {}
     if kwargs.get("job_check"):
         download_kwargs["job_check"] = True

--- a/bakthat/conf.py
+++ b/bakthat/conf.py
@@ -19,6 +19,8 @@ EXCLUDE_FILES = [".bakthatexclude", ".gitignore"]
 
 def load_config(config_file=CONFIG_FILE):
     """ Try to load a yaml config file. """
+    if isinstance(config_file, dict):
+        return {'default': config_file}
     config = {}
     if os.path.isfile(config_file):
         log.debug("Try loading config file: {0}".format(config_file))

--- a/bakthat/helper.py
+++ b/bakthat/helper.py
@@ -266,7 +266,7 @@ class BakHelper:
                               password=kwargs.get("password", self.password),
                               tags=kwargs.get("tags", self.tags),
                               profile=kwargs.get("profile", self.profile),
-                              conf=kwargs.get("conf", self.conf),
+                              config=kwargs.get("conf", self.conf),
                               key=kwargs.get("key", self.key),
                               custom_filename=self.backup_name)
 
@@ -295,7 +295,7 @@ class BakHelper:
                                destination=kwargs.get("destination", self.destination),
                                password=kwargs.get("password", self.password),
                                profile=kwargs.get("profile", self.profile),
-                               conf=kwargs.get("conf", self.conf))
+                               config=kwargs.get("conf", self.conf))
 
     def delete_older_than(self, filename=None, interval=None, **kwargs):
         """Delete backups older than the given interval string.
@@ -325,7 +325,7 @@ class BakHelper:
         return bakthat.delete_older_than(filename, interval,
                                          destination=kwargs.get("destination", self.destination),
                                          profile=kwargs.get("profile", self.profile),
-                                         conf=kwargs.get("conf", self.conf))
+                                         config=kwargs.get("conf", self.conf))
 
     def rotate(self, filename=None, **kwargs):
         """Rotate backup using grandfather-father-son rotation scheme.
@@ -351,4 +351,4 @@ class BakHelper:
         return bakthat.rotate_backups(filename,
                                       destination=kwargs.pop("destination", self.destination),
                                       profile=kwargs.get("profile", self.profile),
-                                      conf=kwargs.get("conf", self.conf))
+                                      config=kwargs.get("conf", self.conf))

--- a/bakthat/helper.py
+++ b/bakthat/helper.py
@@ -181,7 +181,7 @@ class BakHelper:
     """
     def __init__(self, backup_name, **kwargs):
         self.backup_name = backup_name
-        self.dir_prefix = "{0}_".format(backup_name)
+        self.dir_prefix = "{0}_".format(os.path.basename(backup_name))
         self.destination = kwargs.get("destination", DEFAULT_DESTINATION)
         self.password = kwargs.get("password", "")
         self.profile = kwargs.get("profile", "default")

--- a/bakthat/models.py
+++ b/bakthat/models.py
@@ -12,7 +12,6 @@ log = logging.getLogger(__name__)
 
 database = peewee.SqliteDatabase(DATABASE)
 
-
 class JsonField(peewee.CharField):
     """Custom JSON field."""
     def db_value(self, value):
@@ -102,7 +101,7 @@ class Backups(SyncedModel):
         wheres = []
 
         if kwargs.get("profile"):
-            profile = conf.get(kwargs.get("profile"))
+            profile = conf.get(kwargs.get("profile", "default"))
 
             s3_key = hashlib.sha512(profile.get("access_key") +
                                     profile.get("s3_bucket")).hexdigest()


### PR DESCRIPTION
With current version you cant pass bakthat_conf configuration as it said in documentation, it is not handling, my changes will help to handle it

``` python
#! /usr/bin/python

import logging
import sh
logging.basicConfig(level=logging.INFO)

from bakthat.helper import BakHelper

bakthat_conf = {'access_key': 'aaaaaaaaaaaaa',
                'secret_key': 'bbbbbbbbbbbbbbbbbbbb',
                'glacier_vault': '',
                'plugins_dir': '/root',
                's3_bucket': 'backup',
                'region_name': 'us-east-1',
                'rotation': {'days': 7,
                            'first_week_day': 5,
                            'months': 6,
                            'weeks': 6}}



BACKUP_NAME = "my_backup"
BACKUP_PASSWORD = "password"

with BakHelper(BACKUP_NAME, password=BACKUP_PASSWORD, conf=bakthat_conf, tags=["postgresql"]) as bh:
    sh.pg_dump("testdb", _out="dump_testdb.sql")
    bh.backup()
    bh.rotate()
```
