### PR TITLE
Use boto multipart upload for uploading large files to S3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     url="http://docs.bakthat.io",
     packages=find_packages(exclude=['ez_setup', 'tests', 'tests.*']),
     long_description=read('README.rst'),
-    install_requires=["aaargh", "boto", "pycrypto", "beefish", "grandfatherson", "peewee", "byteformat", "pyyaml", "sh", "requests", "events"],
+    install_requires=["aaargh", "boto", "pycrypto", "beefish", "grandfatherson", "peewee", "byteformat", "pyyaml", "sh", "requests", "events", "FileChunkIO"],
     entry_points={'console_scripts': ["bakthat = bakthat:main"]},
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     url="http://docs.bakthat.io",
     packages=find_packages(exclude=['ez_setup', 'tests', 'tests.*']),
     long_description=read('README.rst'),
-    install_requires=["aaargh", "boto", "pycrypto", "beefish", "grandfatherson", "peewee", "byteformat", "pyyaml", "sh", "requests", "events", "FileChunkIO"],
+    install_requires=["aaargh", "boto>=2.48.0", "pycrypto", "beefish", "grandfatherson", "peewee", "byteformat", "pyyaml", "sh", "requests", "events", "FileChunkIO"],
     entry_points={'console_scripts': ["bakthat = bakthat:main"]},
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
This patch allows uploading large files (5gb or larger) to Amazon S3 using boto's multipart transfer. Effectively mitigating #75 and boto/boto#2207. When a file is larger then 2gb then the file will be uploaded in chunks of 100mb. Files smaller then 2gb will be uploaded using the already implemented methodology